### PR TITLE
Return true if user has consumed the action

### DIFF
--- a/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
+++ b/tns-core-modules/ui/editable-text-base/editable-text-base.android.ts
@@ -113,11 +113,13 @@ function initializeEditTextListeners(): void {
                     owner.dismissSoftInput();
                 }
                 owner._onReturnPress();
+                return true;
             }
 
             // If action is ACTION_NEXT then do not close keyboard
             if (actionId === android.view.inputmethod.EditorInfo.IME_ACTION_NEXT) {
                 owner._onReturnPress();
+                return true;
             }
 
             return false;


### PR DESCRIPTION
Based on this: https://developer.android.com/reference/android/widget/TextView.OnEditorActionListener.html
And assuming that the developer will run dismissSoftInput in the owner.dismissSoftInput() only if they need to.
Returning False will close the keyboard regardless.

To help the rest of the community review your change, please ensure:

### PR has a meaningful title
A good title is less than 50 characters and starts with a capital
letter, similar to a good [Git Commit Message] (http://chris.beams.io/posts/git-commit/).

### The commit message references a specific issue in this repo
Fixes/Implements #[Issue Number].

### You have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)
if appropriate.

